### PR TITLE
Change dependency http to '~> 0.6.0'

### DIFF
--- a/sparkpost.gemspec
+++ b/sparkpost.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '0.5.0'
+  spec.add_dependency 'http', '~> 0.6.0'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '<11'


### PR DESCRIPTION
Main reason is `WebMock supports version >= 0.6.0`